### PR TITLE
feat: add config dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Run `yarn lint` and `yarn test` before committing.
+- Keep code formatted using Prettier defaults and Tailwind utility classes.
+- Place React component tests in `src/components/__tests__`. Testing utilities like `@testing-library/react` and Vitest are preferred when available.
+- If modifying configuration files, ensure JSON is valid.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="/src/index.css" rel="stylesheet">
     <title>Vite + React</title>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node src/components/__tests__/ConfigDialog.test.js && node src/components/__tests__/Footer.test.js"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node src/components/__tests__/ConfigDialog.test.js && node src/components/__tests__/Footer.test.js && node src/components/__tests__/Hero.test.js"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#1A202C" />
+  <text x="50" y="65" font-size="60" text-anchor="middle" fill="#A7F3D0">Q</text>
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,21 @@
 
+import { useState } from 'react';
 import Header from './components/Header';
 import Hero from './components/Hero';
 import About from './components/About';
 import Services from './components/Services';
 import Contact from './components/Contact';
+import ConfigDialog from './components/ConfigDialog';
 import '../index.css'; // Import global styles
-import config from './config.json';
+import initialConfig from './config.json';
 
 function App() {
+  const [config, setConfig] = useState(() => {
+    const stored = localStorage.getItem('config');
+    return stored ? JSON.parse(stored) : initialConfig;
+  });
+  const [open, setOpen] = useState(false);
+
   // Set document title
   document.title = config.siteTitle;
 
@@ -18,6 +26,17 @@ function App() {
       --secondary-color: ${config.secondaryColor};
     }
   `;
+
+  const handleSave = (newConfig) => {
+    try {
+      localStorage.setItem('config', JSON.stringify(newConfig));
+      setConfig(newConfig);
+      alert('Configuration saved');
+      setOpen(false);
+    } catch {
+      alert('Failed to save configuration');
+    }
+  };
 
   return (
     <>
@@ -30,6 +49,18 @@ function App() {
           <Services config={config.services} />
           <Contact config={{ ...config.contact, socials: config.socials }} />
         </main>
+        <button
+          onClick={() => setOpen(true)}
+          className="fixed bottom-4 right-4 bg-blue-500 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg"
+        >
+          +
+        </button>
+        <ConfigDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          config={config}
+          onSave={handleSave}
+        />
       </div>
     </>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import About from './components/About';
 import Services from './components/Services';
 import Contact from './components/Contact';
 import ConfigDialog from './components/ConfigDialog';
+import Footer from './components/Footer';
 import '../index.css'; // Import global styles
 import initialConfig from './config.json';
 
@@ -49,6 +50,7 @@ function App() {
           <Services config={config.services} />
           <Contact config={{ ...config.contact, socials: config.socials }} />
         </main>
+        <Footer config={config} />
         <button
           onClick={() => setOpen(true)}
           className="fixed bottom-4 right-4 bg-blue-500 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg"

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,8 +1,8 @@
-import { motion } from 'framer-motion';
+import { motion as Motion } from 'framer-motion';
 
 const About = ({ config }) => {
   return (
-    <motion.section
+    <Motion.section
       id="about"
       className="py-20 bg-gray-50"
       initial={{ opacity: 0, y: 50 }}
@@ -30,7 +30,7 @@ const About = ({ config }) => {
           </div>
         </div>
       </div>
-    </motion.section>
+    </Motion.section>
   );
 };
 

--- a/src/components/ConfigDialog.jsx
+++ b/src/components/ConfigDialog.jsx
@@ -67,13 +67,84 @@ function ConfigDialog({ open, onClose, config, onSave }) {
       <div className="bg-white p-4 rounded w-full max-w-lg max-h-[90vh] overflow-auto">
         <h2 className="text-xl mb-4">Edit Configuration</h2>
         <form onSubmit={handleSubmit} className="space-y-2">
-          <input name="siteTitle" value={form.siteTitle} onChange={handleChange} placeholder="Site Title" className="border p-2 w-full" />
-          <input name="primaryColor" value={form.primaryColor} onChange={handleChange} placeholder="Primary Color" className="border p-2 w-full" />
-          <input name="secondaryColor" value={form.secondaryColor} onChange={handleChange} placeholder="Secondary Color" className="border p-2 w-full" />
-          <textarea name="aboutText" value={form.aboutText} onChange={handleChange} placeholder="About Text" className="border p-2 w-full" />
-          <textarea name="services" value={form.services} onChange={handleChange} placeholder="Services JSON" className="border p-2 w-full" rows={4} />
-          <input name="contactEmail" value={form.contactEmail} onChange={handleChange} placeholder="Contact Email" className="border p-2 w-full" />
-          <input name="contactPhone" value={form.contactPhone} onChange={handleChange} placeholder="Contact Phone" className="border p-2 w-full" />
+          <label className="block">
+            <span className="text-sm">Site Title</span>
+            <input
+              id="siteTitle"
+              name="siteTitle"
+              value={form.siteTitle}
+              onChange={handleChange}
+              placeholder="Site Title"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Primary Color</span>
+            <input
+              id="primaryColor"
+              name="primaryColor"
+              value={form.primaryColor}
+              onChange={handleChange}
+              placeholder="Primary Color"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Secondary Color</span>
+            <input
+              id="secondaryColor"
+              name="secondaryColor"
+              value={form.secondaryColor}
+              onChange={handleChange}
+              placeholder="Secondary Color"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">About Text</span>
+            <textarea
+              id="aboutText"
+              name="aboutText"
+              value={form.aboutText}
+              onChange={handleChange}
+              placeholder="About Text"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Services JSON</span>
+            <textarea
+              id="services"
+              name="services"
+              value={form.services}
+              onChange={handleChange}
+              placeholder="Services JSON"
+              className="border p-2 w-full"
+              rows={4}
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Contact Email</span>
+            <input
+              id="contactEmail"
+              name="contactEmail"
+              value={form.contactEmail}
+              onChange={handleChange}
+              placeholder="Contact Email"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Contact Phone</span>
+            <input
+              id="contactPhone"
+              name="contactPhone"
+              value={form.contactPhone}
+              onChange={handleChange}
+              placeholder="Contact Phone"
+              className="border p-2 w-full"
+            />
+          </label>
           {error && <p className="text-red-500 text-sm">{error}</p>}
           <div className="flex justify-end gap-2 pt-2">
             <button type="button" onClick={onClose} className="px-3 py-1 border rounded">Cancel</button>

--- a/src/components/ConfigDialog.jsx
+++ b/src/components/ConfigDialog.jsx
@@ -3,10 +3,13 @@ import { useState, useEffect } from 'react';
 function ConfigDialog({ open, onClose, config, onSave }) {
   const [form, setForm] = useState({
     siteTitle: '',
+    tagline: '',
+    heroImage: '',
     primaryColor: '',
     secondaryColor: '',
     aboutText: '',
     services: '[]',
+    socials: '{}',
     contactEmail: '',
     contactPhone: ''
   });
@@ -16,10 +19,13 @@ function ConfigDialog({ open, onClose, config, onSave }) {
     if (open) {
       setForm({
         siteTitle: config.siteTitle || '',
+        tagline: config.tagline || '',
+        heroImage: config.heroImage || '',
         primaryColor: config.primaryColor || '',
         secondaryColor: config.secondaryColor || '',
         aboutText: config.about?.text || '',
         services: JSON.stringify(config.services || [], null, 2),
+        socials: JSON.stringify(config.socials || {}, null, 2),
         contactEmail: config.contact?.email || '',
         contactPhone: config.contact?.phone || ''
       });
@@ -34,6 +40,7 @@ function ConfigDialog({ open, onClose, config, onSave }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     let services;
+    let socials;
     try {
       services = JSON.parse(form.services);
     } catch {
@@ -41,13 +48,22 @@ function ConfigDialog({ open, onClose, config, onSave }) {
       return;
     }
     try {
+      socials = JSON.parse(form.socials);
+    } catch {
+      setError('Socials must be valid JSON');
+      return;
+    }
+    try {
       const newConfig = {
         ...config,
         siteTitle: form.siteTitle,
+        tagline: form.tagline,
+        heroImage: form.heroImage,
         primaryColor: form.primaryColor,
         secondaryColor: form.secondaryColor,
         about: { ...(config.about || {}), text: form.aboutText },
         services,
+        socials,
         contact: {
           ...(config.contact || {}),
           email: form.contactEmail,
@@ -60,6 +76,24 @@ function ConfigDialog({ open, onClose, config, onSave }) {
     }
   };
 
+  const fetchHeroImage = async () => {
+    const accessKey = import.meta.env.VITE_UNSPLASH_ACCESS_KEY || 'UNSPLASH_ACCESS_KEY';
+    try {
+      const res = await fetch(
+        `https://api.unsplash.com/photos/random?orientation=landscape&client_id=${accessKey}`
+      );
+      const data = await res.json();
+      const url = data?.urls?.regular;
+      if (url) {
+        setForm((prev) => ({ ...prev, heroImage: url }));
+      } else {
+        setError('Failed to fetch hero image');
+      }
+    } catch {
+      setError('Failed to fetch hero image');
+    }
+  };
+
   if (!open) return null;
 
   return (
@@ -67,13 +101,127 @@ function ConfigDialog({ open, onClose, config, onSave }) {
       <div className="bg-white p-4 rounded w-full max-w-lg max-h-[90vh] overflow-auto">
         <h2 className="text-xl mb-4">Edit Configuration</h2>
         <form onSubmit={handleSubmit} className="space-y-2">
-          <input name="siteTitle" value={form.siteTitle} onChange={handleChange} placeholder="Site Title" className="border p-2 w-full" />
-          <input name="primaryColor" value={form.primaryColor} onChange={handleChange} placeholder="Primary Color" className="border p-2 w-full" />
-          <input name="secondaryColor" value={form.secondaryColor} onChange={handleChange} placeholder="Secondary Color" className="border p-2 w-full" />
-          <textarea name="aboutText" value={form.aboutText} onChange={handleChange} placeholder="About Text" className="border p-2 w-full" />
-          <textarea name="services" value={form.services} onChange={handleChange} placeholder="Services JSON" className="border p-2 w-full" rows={4} />
-          <input name="contactEmail" value={form.contactEmail} onChange={handleChange} placeholder="Contact Email" className="border p-2 w-full" />
-          <input name="contactPhone" value={form.contactPhone} onChange={handleChange} placeholder="Contact Phone" className="border p-2 w-full" />
+          <label className="block">
+            <span className="text-sm">Site Title</span>
+            <input
+              id="siteTitle"
+              name="siteTitle"
+              value={form.siteTitle}
+              onChange={handleChange}
+              placeholder="Site Title"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Tagline</span>
+            <input
+              id="tagline"
+              name="tagline"
+              value={form.tagline}
+              onChange={handleChange}
+              placeholder="Tagline"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Hero Image URL</span>
+            <div className="flex gap-2">
+              <input
+                id="heroImage"
+                name="heroImage"
+                value={form.heroImage}
+                onChange={handleChange}
+                placeholder="Hero Image URL"
+                className="border p-2 w-full"
+              />
+              <button
+                type="button"
+                onClick={fetchHeroImage}
+                className="px-2 py-1 bg-gray-200 rounded"
+              >
+                Random Hero Image
+              </button>
+            </div>
+          </label>
+          <label className="block">
+            <span className="text-sm">Primary Color</span>
+            <input
+              id="primaryColor"
+              name="primaryColor"
+              value={form.primaryColor}
+              onChange={handleChange}
+              placeholder="Primary Color"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Secondary Color</span>
+            <input
+              id="secondaryColor"
+              name="secondaryColor"
+              value={form.secondaryColor}
+              onChange={handleChange}
+              placeholder="Secondary Color"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">About Text</span>
+            <textarea
+              id="aboutText"
+              name="aboutText"
+              value={form.aboutText}
+              onChange={handleChange}
+              placeholder="About Text"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Services JSON</span>
+            <textarea
+              id="services"
+              name="services"
+              value={form.services}
+              onChange={handleChange}
+              placeholder="Services JSON"
+              className="border p-2 w-full"
+              rows={4}
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Socials JSON</span>
+            <textarea
+              id="socials"
+              name="socials"
+              value={form.socials}
+              onChange={handleChange}
+              placeholder="Socials JSON"
+              className="border p-2 w-full"
+              rows={4}
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Contact Email</span>
+            <input
+              id="contactEmail"
+              name="contactEmail"
+              value={form.contactEmail}
+              onChange={handleChange}
+              placeholder="Contact Email"
+              className="border p-2 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm">Contact Phone</span>
+            <input
+              id="contactPhone"
+              name="contactPhone"
+              value={form.contactPhone}
+              onChange={handleChange}
+              placeholder="Contact Phone"
+              className="border p-2 w-full"
+            />
+          </label>
           {error && <p className="text-red-500 text-sm">{error}</p>}
           <div className="flex justify-end gap-2 pt-2">
             <button type="button" onClick={onClose} className="px-3 py-1 border rounded">Cancel</button>

--- a/src/components/ConfigDialog.jsx
+++ b/src/components/ConfigDialog.jsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+
+function ConfigDialog({ open, onClose, config, onSave }) {
+  const [form, setForm] = useState({
+    siteTitle: '',
+    primaryColor: '',
+    secondaryColor: '',
+    aboutText: '',
+    services: '[]',
+    contactEmail: '',
+    contactPhone: ''
+  });
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setForm({
+        siteTitle: config.siteTitle || '',
+        primaryColor: config.primaryColor || '',
+        secondaryColor: config.secondaryColor || '',
+        aboutText: config.about?.text || '',
+        services: JSON.stringify(config.services || [], null, 2),
+        contactEmail: config.contact?.email || '',
+        contactPhone: config.contact?.phone || ''
+      });
+      setError('');
+    }
+  }, [open, config]);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    let services;
+    try {
+      services = JSON.parse(form.services);
+    } catch {
+      setError('Services must be valid JSON');
+      return;
+    }
+    try {
+      const newConfig = {
+        ...config,
+        siteTitle: form.siteTitle,
+        primaryColor: form.primaryColor,
+        secondaryColor: form.secondaryColor,
+        about: { ...(config.about || {}), text: form.aboutText },
+        services,
+        contact: {
+          ...(config.contact || {}),
+          email: form.contactEmail,
+          phone: form.contactPhone
+        }
+      };
+      onSave(newConfig);
+    } catch {
+      setError('Failed to save configuration');
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded w-full max-w-lg max-h-[90vh] overflow-auto">
+        <h2 className="text-xl mb-4">Edit Configuration</h2>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <input name="siteTitle" value={form.siteTitle} onChange={handleChange} placeholder="Site Title" className="border p-2 w-full" />
+          <input name="primaryColor" value={form.primaryColor} onChange={handleChange} placeholder="Primary Color" className="border p-2 w-full" />
+          <input name="secondaryColor" value={form.secondaryColor} onChange={handleChange} placeholder="Secondary Color" className="border p-2 w-full" />
+          <textarea name="aboutText" value={form.aboutText} onChange={handleChange} placeholder="About Text" className="border p-2 w-full" />
+          <textarea name="services" value={form.services} onChange={handleChange} placeholder="Services JSON" className="border p-2 w-full" rows={4} />
+          <input name="contactEmail" value={form.contactEmail} onChange={handleChange} placeholder="Contact Email" className="border p-2 w-full" />
+          <input name="contactPhone" value={form.contactPhone} onChange={handleChange} placeholder="Contact Phone" className="border p-2 w-full" />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="px-3 py-1 border rounded">Cancel</button>
+            <button type="submit" className="px-3 py-1 bg-blue-500 text-white rounded">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ConfigDialog;

--- a/src/components/ConfigDialog.jsx
+++ b/src/components/ConfigDialog.jsx
@@ -83,7 +83,7 @@ function ConfigDialog({ open, onClose, config, onSave }) {
         `https://api.unsplash.com/photos/random?orientation=landscape&client_id=${accessKey}`
       );
       const data = await res.json();
-      const url = data?.urls?.regular;
+      const url = data?.urls?.full;
       if (url) {
         setForm((prev) => ({ ...prev, heroImage: url }));
       } else {
@@ -134,6 +134,7 @@ function ConfigDialog({ open, onClose, config, onSave }) {
                 placeholder="Hero Image URL"
                 className="border p-2 w-full"
               />
+
               <button
                 type="button"
                 onClick={fetchHeroImage}
@@ -142,6 +143,7 @@ function ConfigDialog({ open, onClose, config, onSave }) {
                 Random Hero Image
               </button>
             </div>
+            <p className="text-sm text-gray-500">Type `/assets/images/cafe-hero.jpg` for default image</p>
           </label>
           <label className="block">
             <span className="text-sm">Primary Color</span>

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,5 +1,5 @@
 // src/components/Contact.jsx
-import { motion } from 'framer-motion';
+import { motion as Motion } from 'framer-motion';
 import { FiMail, FiPhone, FiInstagram, FiFacebook } from 'react-icons/fi';
 
 const Contact = ({ config }) => {
@@ -8,7 +8,7 @@ const Contact = ({ config }) => {
   const { socials } = config; // Assuming socials might be passed separately or within contact
 
   return (
-    <motion.section
+    <Motion.section
       id="contact"
       style={{
        background: bgColor
@@ -52,7 +52,7 @@ const Contact = ({ config }) => {
           {ctaText}
         </a>
       </div>
-    </motion.section>
+    </Motion.section>
   );
 };
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function Footer({ config }) {
+  return (
+    <footer className="bg-gray-900 text-white text-center py-4" data-testid="footer">
+      <p>&copy; {new Date().getFullYear()} {config.businessName}</p>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { motion as Motion } from 'framer-motion';
 
 const Header = ({ config }) => {
   const navLinks = [
@@ -9,7 +9,7 @@ const Header = ({ config }) => {
   ];
 
   return (
-    <motion.header
+    <Motion.header
       className="sticky top-0 z-50 w-full bg-white/80 backdrop-blur-sm shadow-md"
       initial={{ y: -100 }}
       animate={{ y: 0 }}
@@ -39,7 +39,7 @@ const Header = ({ config }) => {
           ))}
         </nav>
       </div>
-    </motion.header>
+    </Motion.header>
   );
 };
 

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { motion as Motion } from 'framer-motion';
 
 const Services = ({ config }) => {
   const containerVariants = {
@@ -25,7 +25,7 @@ const Services = ({ config }) => {
         <h2 className="text-4xl font-bold text-gray-800 mb-2">Our Services</h2>
         <p className="text-gray-600 mb-12">What we offer</p>
 
-        <motion.div
+        <Motion.div
           className="grid gap-8 md:grid-cols-3"
           variants={containerVariants}
           initial="hidden"
@@ -33,16 +33,16 @@ const Services = ({ config }) => {
           viewport={{ once: true, amount: 0.2 }} // Animate once when 20% of it is in view
         >
           {config.map((service, index) => (
-            <motion.div
+            <Motion.div
               key={index}
               className="bg-gray-50 p-8 rounded-xl shadow-lg hover:shadow-2xl transition-shadow duration-300"
               variants={itemVariants}
             >
               <h3 className="text-2xl font-bold text-primary mb-4">{service.title}</h3>
               <p className="text-gray-600">{service.description}</p>
-            </motion.div>
+            </Motion.div>
           ))}
-        </motion.div>
+        </Motion.div>
       </div>
     </section>
   );

--- a/src/components/__tests__/ConfigDialog.test.js
+++ b/src/components/__tests__/ConfigDialog.test.js
@@ -1,0 +1,32 @@
+/* eslint-env node */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const content = readFileSync(join(__dirname, '../ConfigDialog.jsx'), 'utf8');
+const labels = [
+  'Site Title',
+  'Tagline',
+  'Hero Image URL',
+  'Random Hero Image',
+  'Primary Color',
+  'Secondary Color',
+  'About Text',
+  'Services JSON',
+  'Socials JSON',
+  'Contact Email',
+  'Contact Phone'
+];
+labels.forEach((label) => {
+  if (!content.includes(label)) {
+    throw new Error(`Missing label ${label}`);
+  }
+});
+
+if (!content.includes('https://api.unsplash.com/photos/random')) {
+  throw new Error('Missing Unsplash API call');
+}
+console.log('ConfigDialog labels test passed');

--- a/src/components/__tests__/ConfigDialog.test.js
+++ b/src/components/__tests__/ConfigDialog.test.js
@@ -1,0 +1,24 @@
+/* eslint-env node */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const content = readFileSync(join(__dirname, '../ConfigDialog.jsx'), 'utf8');
+const labels = [
+  'Site Title',
+  'Primary Color',
+  'Secondary Color',
+  'About Text',
+  'Services JSON',
+  'Contact Email',
+  'Contact Phone'
+];
+labels.forEach((label) => {
+  if (!content.includes(label)) {
+    throw new Error(`Missing label ${label}`);
+  }
+});
+console.log('ConfigDialog labels test passed');

--- a/src/components/__tests__/Footer.test.js
+++ b/src/components/__tests__/Footer.test.js
@@ -1,0 +1,13 @@
+/* eslint-env node */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const content = readFileSync(join(__dirname, '../Footer.jsx'), 'utf8');
+if (!content.includes('bg-gray-900')) {
+  throw new Error('Footer background class missing');
+}
+console.log('Footer background test passed');

--- a/src/components/__tests__/Hero.test.js
+++ b/src/components/__tests__/Hero.test.js
@@ -1,0 +1,13 @@
+/* eslint-env node */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const content = readFileSync(join(__dirname, '../Hero.jsx'), 'utf8');
+if (!content.includes('config.heroImage')) {
+  throw new Error('Hero component missing heroImage usage');
+}
+console.log('Hero heroImage test passed');


### PR DESCRIPTION
## Summary
- add floating action button to open configuration dialog
- allow editing site details through modal with basic validation and localStorage persistence
- adjust animation imports for lint compliance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a35c4f2be88328bc8515fe94c9c8f3